### PR TITLE
Feature#55

### DIFF
--- a/src/components/pages/BookDetail.jsx
+++ b/src/components/pages/BookDetail.jsx
@@ -145,6 +145,7 @@ export default function BookDetail({ history }) {
           variant="contained"
           color="primary"
           disableElevation
+          onClick={() => history.push(`/book/detail/${id}`)}
         >
           読了
         </Button>

--- a/src/components/pages/ReadForm.jsx
+++ b/src/components/pages/ReadForm.jsx
@@ -7,7 +7,7 @@ import TextField from "@material-ui/core/TextField";
 import { useForm } from "react-hook-form";
 import { useParams } from "react-router-dom";
 import firebase from "../../firebase/firebase";
-const ReadForm = () => {
+const ReadForm = ({history}) => {
   const { register, handleSubmit } = useForm();
   const useStyles = makeStyles((theme) => ({
     root: {
@@ -66,7 +66,12 @@ const ReadForm = () => {
   return (
     <Container component="main" maxWidth="xs">
       <div className={classes.paper}>
-        <Button className={classes.back}>←戻る</Button>
+        <Button
+          onClick={() => history.push(`/book/${id}`)}
+          className={classes.back}
+        >
+          ←戻る
+        </Button>
         <h3 className={classes.ryou}>読了*</h3>
         <form>
           <div className={classes.root}>

--- a/src/reducks/store/store.jsx
+++ b/src/reducks/store/store.jsx
@@ -11,6 +11,7 @@ export default function createStore() {
   return reduxCreateStore(
     combineReducers({
       books: BooksReducer,
-    })
+    }),
+   window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__()
   );
 }


### PR DESCRIPTION
## Issue

Closes #55 

## 今回の PR で行ったこと

-
mergeされていたため、pullした後にbranchをfeature#55としてきって再度以下を作成した
bookdetailの読了ボタンを押した時にreadFormに画面遷移する
readFormの戻るボタンでbookdetailに戻る
redux-devtoolsの導入

## 動作確認(どのような動作確認を行ったのか？ 結果はどうか？)

-
ボタンを押した時に適当な画面遷移を確認

## 影響範囲(行った作業によってどこまで影響が及ぶようになるか)

-

## 実装するにあたって参考にした URL

-
https://qiita.com/zaburo/items/92dfc007395615638ebb
## 確認して欲しいこと

-

## 懸念点

-
先日話した時はpullせずにそのままボタンを自分で作成して、画面遷移を行えるようにするという話でしたが、
pullしてから作成した方が飯田さんの負担も少ないと考えmergeされたものに追加で画面遷移のコードを追加しました。
このことによって予想外のことが起きていないか心配